### PR TITLE
ゴルフスコア判定問題初回コミット

### DIFF
--- a/python/golf_score.py
+++ b/python/golf_score.py
@@ -1,0 +1,26 @@
+regulations, strokes = [list(map(int, input().split(","))) for _ in range(2)]
+
+results = []
+result = ""
+for regulation, stroke in zip(regulations, strokes):
+    if stroke > regulation:
+        if (stroke - regulation) == 1:
+            result = "ボギー"
+        else:
+            result = str(stroke - regulation) + "ボギー"
+    elif stroke == regulation:
+        result = "パー"
+    elif stroke == 1:
+        if regulation == 5:
+            result = "コンドル"
+        else:
+            result = "ホールインワン"
+    elif (stroke - regulation) == -1:
+        result = "バーディ"
+    elif (stroke - regulation) == -2:
+        result = "イーグル"
+    elif (stroke - regulation) == -3 and regulation == 5:
+        result = "アルバトロス"
+
+    results.append(result)
+print(",".join(results))

--- a/python/golf_score.py
+++ b/python/golf_score.py
@@ -1,26 +1,25 @@
 regulations, strokes = [list(map(int, input().split(","))) for _ in range(2)]
 
+SCORE_MAP = {
+    -4: "コンドル",
+    -3: "アルバトロス",
+    -2: "イーグル",
+    -1: "バーディ",
+    0: "パー",
+    1: "ボギー",
+}
+
 results = []
 result = ""
 for regulation, stroke in zip(regulations, strokes):
-    if stroke > regulation:
-        if (stroke - regulation) == 1:
-            result = "ボギー"
-        else:
-            result = str(stroke - regulation) + "ボギー"
-    elif stroke == regulation:
-        result = "パー"
-    elif stroke == 1:
-        if regulation == 5:
-            result = "コンドル"
-        else:
-            result = "ホールインワン"
-    elif (stroke - regulation) == -1:
-        result = "バーディ"
-    elif (stroke - regulation) == -2:
-        result = "イーグル"
-    elif (stroke - regulation) == -3 and regulation == 5:
-        result = "アルバトロス"
+    score = stroke - regulation
+
+    if stroke == 1 and regulation != 5:
+        result = "ホールインワン"
+    elif score >= 2:
+        result = str(stroke - regulation) + "ボギー"
+    else:
+        result = SCORE_MAP[score]
 
     results.append(result)
 print(",".join(results))


### PR DESCRIPTION
## 課題のリンク

* https://kirara-code.net/HappinessChain/tasks/106?chapterId=38

## やったこと

* Python ゴルフスコア判定問題


## 動作確認方法

* 任意のディレクトリにgolf_score.pyを配置する。
* golf_score.pyと同一階層にcase_1.txtを作成し以下を入力し保存する。
```
4,4,5,3,5,4,4,3,4,4,5,4,4,3,4,4,3,5
2,3,1,5,8,3,5,1,5,6,2,5,7,2,5,5,2,6
```
* 以下のコマンドを実行する
`cat case_1.txt | python golf_score.py`

* 実行結果
テストケース1
<img width="652" alt="image" src="https://github.com/user-attachments/assets/3abf2854-5309-48eb-a462-b84c07f6c4c3" />

テストケース2
<img width="643" alt="image" src="https://github.com/user-attachments/assets/0d89d93a-d101-4784-a8f1-1b6b52f47bb5" />

## その他

